### PR TITLE
Simplify and fix the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,29 @@ php:
   - hhvm
 
 env:
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=2.5.*
-    - SYMFONY_VERSION=dev-master
+  global:
+    - SYMFONY_VERSION=2.6.*
 
 matrix:
+    include:
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.4.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.5.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=dev-master
     fast_finish: true
     allow_failures:
+        - env: SYMFONY_VERSION=2.7.*
         - env: SYMFONY_VERSION=dev-master
 
 before_script:
     - composer self-update
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+    - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
     - composer update --dev
 
 script: phpunit --coverage-text


### PR DESCRIPTION
- requiring only FrameworkBundle at a specific version does not actually test against this version of Symfony, because FrameworkBundle 2.3 is able to use HttpFoundation and Routing 2.6 for instance.
- testing all combination of symfony versions and PHP versions is not really needed (Symfony is already known to work on all these versions thanks to its own testsuite). A smaller build matrix means faster builds given that Travis only allows 5 concurrent jobs per organization. This change brings it down from 20 jobs to 10, while adding testing for Symfony 2.6 and 2.7 which were not yet covered (they would have bumped it to 30 jobs on the previous matrix)