### PR TITLE
Passing all headers from legacy symfony1 application

### DIFF
--- a/Kernel/Symfony14Kernel.php
+++ b/Kernel/Symfony14Kernel.php
@@ -120,7 +120,10 @@ class Symfony14Kernel extends LegacyKernel
         $response = new Response($legacyResponse->getContent(), $legacyResponse->getStatusCode());
         $response->setCharset($legacyResponse->getCharset());
         $response->setStatusCode($legacyResponse->getStatusCode());
-        $response->headers->set('Content-Type', $legacyResponse->getContentType());
+
+        foreach($legacyResponse->getHttpHeaders() as $headerName => $headerValue) {
+            $response->headers->set($headerName, $headerValue);
+        }
 
         return $response;
     }


### PR DESCRIPTION
Hi @benja-M-1 :)

`Symfony14Kernel` cut away all http headers(except `Content-Type`) which symfony 1 application returned. 
This patch fixes such behavior. 
I hope it looks fine for you.

Regards