### PR TITLE
more flexibility with codeigniter setups

### DIFF
--- a/Kernel/CodeIgniterKernel.php
+++ b/Kernel/CodeIgniterKernel.php
@@ -10,6 +10,7 @@ namespace Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel {
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Theodo\Evolution\Bundle\LegacyWrapperBundle\Autoload\LegacyClassLoaderInterface;
+    use Theodo\Evolution\Bundle\LegacyWrapperBundle\Exception\CodeIgniterException;
 
     class CodeIgniterKernel extends LegacyKernel
     {

--- a/Kernel/CodeIgniterKernel.php
+++ b/Kernel/CodeIgniterKernel.php
@@ -187,8 +187,7 @@ namespace Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel {
 
             // Path to the system folder
             $systemFolderPath = $this->getRootDir() . '/system/';
-            if (array_key_exists('system', $this->options))
-            {
+            if (array_key_exists('system', $this->options)) {
                 $systemFolderPath = $this->options['system'];
             }
 
@@ -202,8 +201,7 @@ namespace Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel {
 
             // The path to the "application" folder
             $applicationPath = $this->getRootDir() . '/application/';
-            if (array_key_exists('application', $this->options))
-            {
+            if (array_key_exists('application', $this->options)) {
                 $applicationPath = $this->options['application'];
             }
 

--- a/Kernel/CodeIgniterKernel.php
+++ b/Kernel/CodeIgniterKernel.php
@@ -186,7 +186,13 @@ namespace Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel {
             define('EXT', '.php');
 
             // Path to the system folder
-            define('BASEPATH', str_replace("\\", "/", realpath($this->getRootDir() . '/system/') . '/'));
+            $systemFolderPath = $this->getRootDir() . '/system/';
+            if (array_key_exists('system', $this->options))
+            {
+                $systemFolderPath = $this->options['system'];
+            }
+
+            define('BASEPATH', str_replace("\\", "/", realpath($systemFolderPath) . '/'));
 
             // Path to the front controller (this file)
             define('FCPATH', $container->getParameter('kernel.root_dir') . '/../web');
@@ -195,7 +201,13 @@ namespace Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel {
             define('SYSDIR', trim(strrchr(trim(BASEPATH, '/'), '/'), '/'));
 
             // The path to the "application" folder
-            define('APPPATH', $this->getRootDir() . '/application/');
+            $applicationPath = $this->getRootDir() . '/application/';
+            if (array_key_exists('application', $this->options))
+            {
+                $applicationPath = $this->options['application'];
+            }
+
+            define('APPPATH', realpath($applicationPath) . '/');
 
             // The path to the "sparks" folder
             define('SPARKPATH', $this->getRootDir() . '/sparks/');

--- a/Resources/doc/codeigniter.rst
+++ b/Resources/doc/codeigniter.rst
@@ -30,5 +30,5 @@ appropriate folders
                 environment: %kernel.environment%
                 version: '2.1.2'
                 core: false
-                system: %kernel.root_dir%/../library/CI_2_2_0/system
-                application: %kernel.root_dir%/../library/CI_2_2_0/application
+                system: %kernel.root_dir%/../library/CodeIgniter_2.1.4/system
+                application: %kernel.root_dir%/../application

--- a/Resources/doc/codeigniter.rst
+++ b/Resources/doc/codeigniter.rst
@@ -14,3 +14,21 @@ Here is the basic configuration for a CodeIgniter application:
                 version: '2.1.2'
                 core: false
 
+Slightly advanced configuration for CodeIgniter application:
+* where the system folder and application folder reside in locations other than the `%root_dir%/system` and
+`%root_dir%/application paths`. If these are not set, they default to looking under the `%root_dir%` for the
+appropriate folders
+
+::
+
+    theodo_evolution_legacy_wrapper:
+        root_dir: %kernel.root_dir%/../legacy
+        class_loader_id: theodo_evolution_legacy_wrapper.autoload.codeigniter_class_loader
+        kernel:
+            id: theodo_evolution_legacy_wrapper.legacy_kernel.codeigniter
+            options:
+                environment: %kernel.environment%
+                version: '2.1.2'
+                core: false
+                system: %kernel.root_dir%/../library/CI_2_2_0/system
+                application: %kernel.root_dir%/../library/CI_2_2_0/application

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -24,6 +24,7 @@ Add the following lines to your composer.json:
 
     "require": {
         ...
+        "composer/composer": "~1.0@dev",
         "theodo-evolution/legacy-wrapper-bundle": "~1.0"
         ...
     },


### PR DESCRIPTION
Allow system and application folder locations to be configurable.
 - Document usage in resources.
 - I had an environment that has split the system and application folders because of reasons (inherited legacy code). Couldn't use the configuration examples and had to write a "custom" kernel which copied `CodeIgniterKernel` and set those to what was needed and then needed to write a "custom" autoloader which was the `CodeIgniterClassLoader` file with the throw exception for not instance of `CodeIgniterKernel` removed. This change allows me (and anyone else with split location setups) to still use the Bundle without hacking around the existing kernel.
 - Ability to set the folder paths gets rid of a lot of unnecessary code (for split location setups) and is more maintainable.

composer install/update states that there is a composer requirement for this bundle and will error out. adding installation line so that install will happen properly