### PR TITLE
Make the bundle compatible with Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 env:
   global:
-    - SYMFONY_VERSION=2.6.*
+    - SYMFONY_VERSION=2.8.*
 
 matrix:
     include:
@@ -23,6 +23,10 @@ matrix:
           env: SYMFONY_VERSION=2.5.*
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*
         - php: 5.6
           env: SYMFONY_VERSION=dev-master
     fast_finish: true

--- a/Kernel/Symfony14Kernel.php
+++ b/Kernel/Symfony14Kernel.php
@@ -36,8 +36,14 @@ class Symfony14Kernel extends LegacyKernel
             $this->classLoader->autoload();
         }
 
+        if ($container->has('request_stack')) {
+            $request = $container->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $container->get('request');
+        }
+
         $dispatcher = $container->get('event_dispatcher');
-        $event = new LegacyKernelBootEvent($container->get('request'), $this->options);
+        $event = new LegacyKernelBootEvent($request, $this->options);
         $dispatcher->dispatch(LegacyKernelEvents::BOOT, $event);
         $this->options = $event->getOptions();
 

--- a/Tests/Kernel/Symfony14KernelTest.php
+++ b/Tests/Kernel/Symfony14KernelTest.php
@@ -7,9 +7,11 @@ use Prophecy\PhpUnit\ProphecyTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Kernel;
 use Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel\Event\LegacyKernelBootEvent;
 use Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel\Symfony14Kernel;
 
@@ -40,7 +42,13 @@ class Symfony14KernelTest extends ProphecyTestCase
         $container   = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->get('session')->willReturn($session);
         $container->get('event_dispatcher')->willReturn($eventDispatcher);
-        $container->get('request')->willReturn($request);
+        if (Kernel::MAJOR_VERSION == 2) {
+            $container->get('request')->willReturn($request);
+        } else {
+            $request_stack = new RequestStack();
+            $request_stack->push($request);
+            $container->get('request_stack')->willReturn($request_stack);
+        }
 
         $classLoader->setKernel(Argument::type('Theodo\Evolution\Bundle\LegacyWrapperBundle\Kernel\Symfony14Kernel'))->shouldBeCalled();
         $classLoader->isAutoloaded()->willReturn(false);
@@ -77,7 +85,14 @@ class Symfony14KernelTest extends ProphecyTestCase
 
         $container   = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->get('event_dispatcher')->willReturn($eventDispatcher);
-        $container->get('request')->willReturn($request);
+
+        if (Kernel::MAJOR_VERSION == 2) {
+            $container->get('request')->willReturn($request);
+        } else {
+            $request_stack = new RequestStack();
+            $request_stack->push($request);
+            $container->get('request_stack')->willReturn($request_stack);
+        }
 
         $kernel = new Symfony14Kernel();
         $kernel->setRootDir($_ENV['THEODO_EVOLUTION_FAKE_PROJECTS'].'/symfony14');

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.3",
         "composer/composer": "~1.0@dev",
-        "symfony/framework-bundle": "~2.1"
+        "symfony/framework-bundle": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
Symfony 3 has deprecated and removed the 'request' service from the DI
Container. Instead, it is now required to use the 'request_stack'
service.
