### PR TITLE
start ci troubleshooting document

### DIFF
--- a/Resources/doc/codeigniter.rst
+++ b/Resources/doc/codeigniter.rst
@@ -1,5 +1,5 @@
 Wrap CodeIgniter
-=================
+================
 
 Here is the basic configuration for a CodeIgniter application:
 ::
@@ -32,3 +32,4 @@ appropriate folders
                 core: false
                 system: %kernel.root_dir%/../library/CodeIgniter_2.1.4/system
                 application: %kernel.root_dir%/../application
+

--- a/Resources/doc/codeignitertroubleshooting.md
+++ b/Resources/doc/codeignitertroubleshooting.md
@@ -1,0 +1,10 @@
+#CodeIgniter Troubleshooting
+
+- Symfony Debug Toolbar 404|500
+    - add the following to your CodeIgniter `routes.php` config file:
+    
+    
+        if (is_bool(strpos(ENVIRONMENT, 'prod')))
+        {
+            $route['404_override'] = 'nomEmptyStringValue';
+        }


### PR DESCRIPTION
- correct RST warning: Title length must match the underline
- correct RST error: Blank line is required after literal block
- begin troubleshooting section

saw https://github.com/theodo/TheodoEvolutionLegacyWrapperBundle/issues/6
and thought I would add in a solution to some issues I've encountered while using this wrapper bundle.

I have a solution for an issue I was experiencing. Haven't had time to step debug why it no longer conflicts the Symfony Web Debug Toolbar, but it works.
