### PR TITLE
Do not migrate session anymore in Sf14 Kernel

### DIFF
--- a/Kernel/Symfony14Kernel.php
+++ b/Kernel/Symfony14Kernel.php
@@ -71,8 +71,6 @@ class Symfony14Kernel extends LegacyKernel
             ob_start();
             \sfContext::createInstance($this->configuration);
             ob_end_flush();
-
-            $session->migrate();
         }
 
         $this->isBooted = true;


### PR DESCRIPTION
`$session->migrate` regenerates the session id. In Sf1 forms, the CSRF token is generated by hashing the secret and the session id. The token is different between the first response (generating the form and the token sent back by the browser on submit) and the form validation (comparing with a new token generated with the new session id).